### PR TITLE
Set `printWidth` to 100 characters.

### DIFF
--- a/packages/prettier-config/index.js
+++ b/packages/prettier-config/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  // ...
+  printWidth: 100,
 };


### PR DESCRIPTION
This is a way to say to Prettier roughly how long you’d like lines to be. Prettier will make both shorter and longer lines, but generally strive to meet the specified printWidth.

The default is 80 and that feels too narrow. 120 felt too wide.